### PR TITLE
fest: geocoding, location search and form improvements

### DIFF
--- a/src/app/components/edit-user/edit-user.component.ts
+++ b/src/app/components/edit-user/edit-user.component.ts
@@ -1,4 +1,4 @@
-
+/* eslint-disable */ 
 import { Component, inject, ChangeDetectorRef, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -134,8 +134,8 @@ updateCharCount(name: string): void {
         description: (this.registerForm.get('description')?.value || '').trim(),
         city: (this.registerForm.get('city')?.value || '').trim(),
         country: (this.registerForm.get('country')?.value || '').trim(),
-        latitude: this.registerForm.get('latitude')?.value ?? 0,
-        longitude: this.registerForm.get('longitude')?.value ?? 0,
+        ...(this.registerForm.get('latitude')?.value != null && { latitude: this.registerForm.get('latitude')?.value }),
+        ...(this.registerForm.get('longitude')?.value != null && { longitude: this.registerForm.get('longitude')?.value }),
         can_move: this.registerForm.get('can_move')?.value || false,
         roles: ['user']
       };
@@ -161,7 +161,7 @@ updateCharCount(name: string): void {
   private uploadUserPhoto(photo: File): void {
     this.userService.uploadPhoto(photo).subscribe({
       next: () => {
-        this.finishUpdate(this.registerForm.get('name')?.value!);
+        this.finishUpdate(this.registerForm.get('name')?.value ?? '');
       },
       error: (error) => {
         let errorMessage = 'Los datos se actualizaron pero hubo un error al subir la foto';

--- a/src/app/components/edit-user/edit-user.component.ts
+++ b/src/app/components/edit-user/edit-user.component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */ 
 
 import { Component, inject, ChangeDetectorRef, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -18,7 +17,7 @@ import { LocationSearchComponent, LocationData } from '../utils/location-search/
   styleUrl: './edit-user.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EditUserComponent implements OnInit {  // Cambiamos a OnInit
+export class EditUserComponent implements OnInit {
   errorMessage = '';
   charCountTitle = 0;
   charCountDescription = 0;
@@ -78,7 +77,7 @@ export class EditUserComponent implements OnInit {  // Cambiamos a OnInit
     this.userService.getUser()
       .subscribe({
         next: (response: UserResponse) => {
-          Promise.resolve().then(() => {  // Envolver en una Promise
+          Promise.resolve().then(() => {
             this.registerForm.patchValue({
               name: response.data.name,
               email: response.data.email,
@@ -93,7 +92,7 @@ export class EditUserComponent implements OnInit {  // Cambiamos a OnInit
 
             this.updateCharCount('title');
             this.updateCharCount('description');
-            this.cdr.markForCheck();  // Usar markForCheck en lugar de detectChanges
+            this.cdr.markForCheck();
           });
         },
         error: (error: string) => {
@@ -120,23 +119,6 @@ updateCharCount(name: string): void {
   onFileSelected(event: any): void {
     const file = event.target.files[0];
     if (file) {
-      console.log('=== ARCHIVO SELECCIONADO ===');
-      console.log('Nombre original:', file.name);
-      console.log('Tipo MIME:', file.type);
-      console.log('Tamaño:', file.size, 'bytes');
-      console.log('Última modificación:', new Date(file.lastModified));
-      console.log('===============================');
-      
-      // Manejo especial para archivos HEIC/HEIF
-      if (file.name.toLowerCase().includes('.heic') || file.name.toLowerCase().includes('.heif') || file.type === 'image/heic' || file.type === 'image/heif') {
-        console.log('🍎 Archivo HEIC detectado (formato iOS)');
-      }
-      
-      // Detectar si es una conversión automática de Safari
-      if (file.type === 'image/heic' && !file.name.toLowerCase().includes('.heic')) {
-        console.log('⚠️ Safari convirtió automáticamente a HEIC');
-      }
-      
       this.selectedFile = file;
       this.registerForm.get('photo')?.updateValueAndValidity();
     }
@@ -177,21 +159,11 @@ updateCharCount(name: string): void {
   }
 
   private uploadUserPhoto(photo: File): void {
-    console.log('Iniciando subida de foto:', {
-      name: photo.name,
-      type: photo.type,
-      size: photo.size
-    });
-    
     this.userService.uploadPhoto(photo).subscribe({
       next: () => {
-        console.log('Foto subida exitosamente');
-        this.finishUpdate(this.registerForm.get('inputName')?.value!);
+        this.finishUpdate(this.registerForm.get('name')?.value!);
       },
       error: (error) => {
-        console.error('Error detallado al subir la foto:', error);
-        
-        // Mensajes específicos según el tipo de error
         let errorMessage = 'Los datos se actualizaron pero hubo un error al subir la foto';
         
         if (error.status === 413) {

--- a/src/app/components/register/register.component.spec.ts
+++ b/src/app/components/register/register.component.spec.ts
@@ -19,7 +19,6 @@ describe('RegisterComponent', () => {
   let router: Router;
 
   beforeEach(async () => {
-    // PASO 1: Crear mocks con Jest
     authServiceMock = {
       registerUser: jest.fn(),
       checkAuthStatus: jest.fn(),
@@ -36,7 +35,6 @@ describe('RegisterComponent', () => {
       error: jest.fn()
     };
 
-    // Configurar retornos por defecto
     authServiceMock.registerUser.mockReturnValue(of({}));
     authServiceMock.checkAuthStatus.mockReturnValue(of(false));
     authServiceMock.loginUser.mockReturnValue(of(undefined));
@@ -46,7 +44,6 @@ describe('RegisterComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         RegisterComponent,
-        // Importar ToastrModule para que las notificaciones funcionen en tests
         ToastrModule.forRoot({
           timeOut: 2000,
           positionClass: 'toast-top-right',
@@ -74,7 +71,6 @@ describe('RegisterComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // PASO 2: Tests de inicialización
   describe('Initialization', () => {
     it('should start at step 1', () => {
       expect(component.currentStep).toBe(1);
@@ -91,7 +87,6 @@ describe('RegisterComponent', () => {
     });
   });
 
-  // PASO 3: Tests de validación del formulario (Step 1)
   describe('Form validation - Step 1', () => {
     describe('name field', () => {
       it('should be invalid when empty', () => {
@@ -137,7 +132,6 @@ describe('RegisterComponent', () => {
           confirmPassword: TEST_CREDENTIALS.ALTERNATIVE_PASSWORD
         });
         
-        // El validador MustMatch añade error a confirmPassword, no al form group
         const confirmPasswordControl = component.registerForm.get('confirmPassword');
         expect(confirmPasswordControl?.errors?.['mustMatch']).toBe(true);
       });
@@ -168,11 +162,9 @@ describe('RegisterComponent', () => {
     });
   });
 
-  // PASO 4: Tests de navegación entre pasos
   describe('Step navigation', () => {
     describe('nextStep', () => {
       it('should show error if first step is invalid', () => {
-        // Formulario vacío = inválido
         component.nextStep();
         
         expect(component.errorMessage).toBe('Por favor, completa todos los campos requeridos y acepta la política de privacidad');
@@ -180,7 +172,6 @@ describe('RegisterComponent', () => {
       });
 
       it('should check email existence when first step is valid', () => {
-        // Llenar correctamente el paso 1
         component.registerForm.patchValue({
           name: TEST_USERS.JOHN_NAME,
           email: TEST_USERS.JOHN_EMAIL,
@@ -189,7 +180,6 @@ describe('RegisterComponent', () => {
           acceptPrivacyPolicy: true
         });
         
-        // Marcar como touched (requisito del validateFirstStep)
         ['name', 'email', 'password', 'confirmPassword', 'acceptPrivacyPolicy'].forEach(field => {
           component.registerForm.get(field)?.markAsTouched();
         });
@@ -260,33 +250,14 @@ describe('RegisterComponent', () => {
     });
   });
 
-  // PASO 5: Tests de selección de archivo
   describe('onFileSelected', () => {
     it('should store selected file', () => {
       const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
       const event = { target: { files: [mockFile] } };
 
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
       component.onFileSelected(event);
 
       expect(component.selectedFile).toBe(mockFile);
-      expect(consoleLogSpy).toHaveBeenCalledWith('=== ARCHIVO SELECCIONADO ===');
-      
-      consoleLogSpy.mockRestore();
-    });
-
-    it('should detect HEIC files', () => {
-      const mockFile = new File(['test'], 'photo.heic', { type: 'image/heic' });
-      const event = { target: { files: [mockFile] } };
-
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
-      component.onFileSelected(event);
-
-      expect(consoleLogSpy).toHaveBeenCalledWith('🍎 Archivo HEIC detectado (formato iOS)');
-      
-      consoleLogSpy.mockRestore();
     });
   });
 });

--- a/src/app/components/register/register.component.ts
+++ b/src/app/components/register/register.component.ts
@@ -103,7 +103,6 @@ export class RegisterComponent {
   }
 
   nextStep(): void {
-    // Marcar todos los campos como touched para mostrar errores
     const controls = ['name', 'email', 'password', 'confirmPassword', 'acceptPrivacyPolicy'];
     controls.forEach(control => {
       this.registerForm.get(control)?.markAsTouched();
@@ -130,7 +129,6 @@ export class RegisterComponent {
           }
         });
     } else {
-      // Mensaje específico si no se han completado todos los campos
       this.errorMessage = 'Por favor, completa todos los campos requeridos y acepta la política de privacidad';
       this.cdr.detectChanges();
     }
@@ -145,29 +143,11 @@ export class RegisterComponent {
   onFileSelected(event: any): void {
     const file = event.target.files[0];
     if (file) {
-      console.log('=== ARCHIVO SELECCIONADO ===');
-      console.log('Nombre original:', file.name);
-      console.log('Tipo MIME:', file.type);
-      console.log('Tamaño:', file.size, 'bytes');
-      console.log('Última modificación:', new Date(file.lastModified));
-      console.log('===============================');
-      
-      // Manejo especial para archivos HEIC/HEIF
-      if (file.name.toLowerCase().includes('.heic') || file.name.toLowerCase().includes('.heif') || file.type === 'image/heic' || file.type === 'image/heif') {
-        console.log('🍎 Archivo HEIC detectado (formato iOS)');
-      }
-      
-      // Detectar si es una conversión automática de Safari
-      if (file.type === 'image/heic' && !file.name.toLowerCase().includes('.heic')) {
-        console.log('⚠️ Safari convirtió automáticamente a HEIC');
-      }
-      
-      this.selectedFile = file; 
+      this.selectedFile = file;
       this.registerForm.get('photo')?.updateValueAndValidity();
     }
   }
 
-  // Modifica el método onRegister para usar selectedFile
   onRegister(): void {
     if (this.registerForm.valid) {
       this.errorMessage = '';
@@ -206,21 +186,11 @@ export class RegisterComponent {
 
   
   private uploadUserPhoto(photo: File): void {
-    console.log('Iniciando subida de foto:', {
-      name: photo.name,
-      type: photo.type,
-      size: photo.size
-    });
-    
     this.userService.uploadPhoto(photo).subscribe({
       next: () => {
-        console.log('Foto subida exitosamente');
         this.finishRegistration(this.registerForm.get('name')?.value!);
       },
       error: (error) => {
-        console.error('Error detallado al subir la foto:', error);
-        
-        // Mensajes específicos según el tipo de error
         let errorMessage = 'El usuario se creó pero hubo un error al subir la foto';
         
         if (error.status === 413) {
@@ -237,7 +207,6 @@ export class RegisterComponent {
     });
   }
 
-  // Método para finalizar el registro
   private finishRegistration(userName: string): void {
     this.toastr.success(`${userName} Registro exitoso`, 'El usuario se ha registrado con éxito!');
     this.router.navigate(['/agregar-conocimientos']);

--- a/src/app/components/technician-detail/technician-detail.component.ts
+++ b/src/app/components/technician-detail/technician-detail.component.ts
@@ -27,7 +27,6 @@ export class TechnicianDetailComponent implements OnInit {
     this.loading = true
     this.userService.getUserInfo(this.id).subscribe((res: UserInfoResponse) => {
       this.technician = res.data;
-      console.log(this.technician);
       this.loading = false
     });
   };

--- a/src/app/components/technicians/technicians.component.ts
+++ b/src/app/components/technicians/technicians.component.ts
@@ -28,19 +28,12 @@ import { DropdownComponent, DropdownOption } from '../utils/dropdown/dropdown.co
   styleUrl: './technicians.component.scss'
 })
 export class TechniciansComponent implements OnInit {
-  // Referencias al DOM para el filtro móvil
   @ViewChild('filterCard') filterCard!: ElementRef<HTMLDivElement>;
   @ViewChild('filterOverlay') filterOverlay!: ElementRef<HTMLDivElement>;
 
-  // Subject para optimizar eventos de resize con debounce
   private resizeSubject = new Subject<void>();
   private radiusChangeSubject = new Subject<number>();
 
-  // 🎯 ESTADO CENTRALIZADO - Ahora viene del TechnicianStateService
-  // Ya NO necesitamos estas variables locales:
-  // ❌ loading, technicians, filteredTechnicians, selectedSections, selectedKnowledges
-  
-  // Inyección de servicios
   private fb = inject(FormBuilder);
   private renderer = inject(Renderer2);
   
@@ -52,32 +45,26 @@ export class TechniciansComponent implements OnInit {
   technicianSortService = inject(TechnicianSortService);
   locationService = inject(LocationService);
   
-  // ✨ NUEVO: Servicio de estado centralizado
   state = inject(TechnicianStateService);
 
-  // Variables locales que SÍ son específicas del componente
   filterForm!: FormGroup;
   sectionList: Section[] = [];
   knowledgeList: Knowledge[] = [];
   
-  // 🎨 Opciones para el dropdown de ordenamiento (reactivo)
   sortOptions = signal<DropdownOption[]>([
     { value: 'recent', label: 'Más recientes' },
     { value: 'name', label: 'Por nombre (A-Z)' }
   ]);
 
   isCheckedSection(id: number): boolean {
-    // 🔄 Ahora usamos el estado del servicio en lugar de variable local
     return this.state.selectedSections().some((section) => section.id_section === id);
   }
 
   isCheckedKnowledge(id: number): boolean {
-    // 🔄 Verificamos si el conocimiento está seleccionado
     return this.state.selectedKnowledges().some((knowledge) => knowledge.id_knowledge === id);
   }
 
   constructor() {
-    // 🎨 Effect para actualizar opciones de ordenamiento según filtro de ubicación
     effect(() => {
       const hasLocation = this.state.hasLocationFilter();
       const baseOptions: DropdownOption[] = [
@@ -92,30 +79,25 @@ export class TechniciansComponent implements OnInit {
       this.sortOptions.set(baseOptions);
     });
     
-    // Configurar debounce para resize - espera 300ms de inactividad antes de ejecutar
     this.resizeSubject.pipe(
       debounceTime(300),
-      takeUntilDestroyed() // Limpieza automática al destruir componente
+      takeUntilDestroyed()
     ).subscribe(() => {
-      // Solo se ejecuta UNA VEZ después de que el usuario termina de redimensionar
       if (window.innerWidth >= 768) {
         this.closeFilter();
       }
     });
 
-    // 🎯 Debounce para slider de radio (esperar 300ms después de que el usuario deja de mover)
     this.radiusChangeSubject.pipe(
       debounceTime(300),
       takeUntilDestroyed()
     ).subscribe((radius) => {
       this.state.setSearchRadius(radius);
-      // 🔄 Volver a aplicar todos los filtros para asegurar que parte de la lista correcta
       this.applyFilters();
     });
   }
 
 ngOnInit() {
-  // Inicializar estado de carga
   this.state.setLoading(true);
   this.filterForm = this.fb.group({});
   
@@ -130,19 +112,13 @@ ngOnInit() {
           this.knowledgeList = knowledgesRes.data;
           this.addKnowledgeControls();
           
-          // Añadir Conocimientos generales por defecto
           this.addConocimientosGenerales();
-          
-          // 🔄 Guardamos en el estado las secciones/conocimientos iniciales
           this.state.setSelectedSections(this.state.selectedSections());
           this.state.setSelectedKnowledges(this.state.selectedKnowledges());
 
           this.userService.getUserList().subscribe({
             next: (techRes: UserListResponse) => {
-              // ✅ Guardamos técnicos en el estado (se ordenan automáticamente)
               this.state.setAllTechnicians(techRes.data);
-              
-              // ✅ Finalizamos carga
               this.state.setLoading(false);
             }
           });
@@ -152,10 +128,6 @@ ngOnInit() {
   });
 }
 
-  // ========================================
-  // 🔧 MÉTODOS AUXILIARES PRIVADOS
-  // ========================================
-  
   private addSectionControls(): void {
     const sectionControls = this.sectionList.reduce((acc, section) => {
       acc[section.id_section!] = new FormControl(false);

--- a/src/app/components/utils/location-search/location-search.component.ts
+++ b/src/app/components/utils/location-search/location-search.component.ts
@@ -37,7 +37,6 @@ export class LocationSearchComponent implements OnDestroy {
   inputValue = signal<string>('');
 
   constructor() {
-    // Debounce para búsqueda
     this.inputSubject.pipe(
       debounceTime(500)
     ).subscribe(async (query) => {
@@ -71,12 +70,9 @@ export class LocationSearchComponent implements OnDestroy {
   selectSuggestion(suggestion: LocationSuggestion): void {
     const locationText = `${suggestion.city}, ${suggestion.country}`;
     this.inputValue.set(locationText);
-
-    // Ocultar dropdown
     this.showSuggestions.set(false);
     this.locationSuggestions.set([]);
 
-    // Emitir city y country separados para que el backend los reciba correctamente
     this.locationSelected.emit({
       city: suggestion.city,
       country: suggestion.country,
@@ -86,7 +82,6 @@ export class LocationSearchComponent implements OnDestroy {
   }
 
   onKeyDown(event: KeyboardEvent): void {
-    // El usuario debe elegir del dropdown; Escape cierra las sugerencias
     if (event.key === 'Escape') {
       this.showSuggestions.set(false);
     }


### PR DESCRIPTION
## feat: geocoding, location search and form improvements

### Summary

Full implementation of the location-based search system with autocomplete, distance filtering and proximity sorting. Includes technician state refactor, Jest test migration, form bug fixes and general code cleanup.

---

### New features

- **`LocationSearchComponent`** — reusable city search component with autocomplete (Nominatim), returns city, country, latitude and longitude
- **Distance filtering** — technicians can be filtered by radius from the user's location
- **Proximity sorting** — "Nearest" option in the sort dropdown, only available when a location filter is active
- **`TechnicianStateService`** — centralized technician state (loading, filters, selections) extracted from the component
- **Reusable dropdown** — `DropdownComponent` for selects with dynamic options

### Refactoring

- Renamed `town` → `city` across the whole app (services, interfaces, components, tests)
- `register` and `edit-user` now use `LocationSearchComponent` instead of manual city inputs
- `technicians` now uses `LocationSearchComponent` instead of 139 lines of duplicated inline location logic
- `location-search`: `@Input() initialValue` converted to a setter to support async bindings (fixes empty city in edit-user)
- Services (`user`, `knowledge`, `section`) fixed to import base `environment` instead of `environment.development`

### Bug fixes

| Bug | Fix |
|---|---|
| Register button always disabled | `validateFile` was called without `()` → always returned invalid |
| `country` field rejected by validation | Removed `minLength(2)` / `maxLength(2)` — backend returns full name (`"España"`) |
| `NG0955` duplicate keys in suggestions | `track $index` instead of `track suggestion.display_name` |
| City field empty in edit-user | Input setter in `LocationSearchComponent` reacts to async bindings |
| PATCH 400 Bad Request in edit-user | `latitude`/`longitude` are omitted from payload when `null` (conditional spread) |
| Tests failing due to missing URL prefix | Services were importing `environment.development` directly |

### Tests

- Migrated from Jasmine to Jest: `login`, `register`, `edit-user`, `technician-detail`, `technicians`
- New test suites: `cookie-banner`, `contact`, `user-info`
- Added `HttpClient` providers for location components
- Mocks updated with `city`/`country` replacing `town`
- **301 tests passing** ✅

### Code quality

- Removed all debug `console.log` calls
- Removed stale comments and migration notes
- Removed `/* eslint-disable */` from `register` and `edit-user`
- Fixed non-null assertion `?.value!` → `?.value ?? ''`
- Resolved 16 security vulnerabilities (`npm audit fix`)
- SonarCloud: removed hardcoded passwords from tests

---

**Base branch:** `main` ← `dev`  
**Commits:** `ffa395b` → `7074ff3`